### PR TITLE
Update ExplainAdminCommand.php

### DIFF
--- a/src/Command/ExplainAdminCommand.php
+++ b/src/Command/ExplainAdminCommand.php
@@ -90,15 +90,19 @@ class ExplainAdminCommand extends Command
             ));
         }
 
-        $output->writeln('');
-        $output->writeln('<info>Datagrid Filters</info>');
-        foreach ($admin->getFilterFieldDescriptions() as $name => $fieldDescription) {
-            $output->writeln(sprintf(
-                '  - % -25s  % -15s % -15s',
-                $name,
-                $fieldDescription->getType(),
-                $fieldDescription->getTemplate()
-            ));
+        try {
+            $output->writeln('');
+            $output->writeln('<info>Datagrid Filters</info>');
+            foreach ($admin->getFilterFieldDescriptions() as $name => $fieldDescription) {
+                $output->writeln(sprintf(
+                    '  - % -25s  % -15s % -15s',
+                    $name,
+                    $fieldDescription->getType(),
+                    $fieldDescription->getTemplate()
+                ));
+            }
+        } catch(\Exception $e){
+            $output->writeln(sprintf('<error>Exception Thrown: %s</error>', $e->getMessage()));
         }
 
         $output->writeln('');


### PR DESCRIPTION
## Continue with the sonata:admin:explain command if exception raised

It's quite possible that your application requires the tokenStorage in order to decide what filters to show. If you do this, it means that the AuthorizationChecker.php throws an exception due to `isGranted` check requiring a set token. This is unavoidable, and prevents the command from continuing, however, it would be better to just continue gracefully. The command doesn't change anything so a try catch allows the getForm reflection debugging to execution plus the other remaining commands.
